### PR TITLE
docs: padroniza formatação dos arquivos markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,49 @@
-# Liderança em Dados (Modern Data Stack)
+# 🎯 Liderança em Dados (Modern Data Stack)
 
-Este repositório documenta minha jornada de desenvolvimento para liderança em Modern Data Stack, combinando aspectos técnicos e estratégicos necessários para liderar equipes de dados em uma empresa de grande porte do setor financeiro.
+## 🔍 Sobre este Projeto
 
-## Objetivo
+Este repositório documenta uma jornada de desenvolvimento para liderança em Modern Data Stack, combinando aspectos técnicos e estratégicos necessários para liderar equipes de dados em uma empresa de grande porte do setor financeiro.
+
+## 📋 Índice de Conceitos
+
+1. **🏗️ [Arquitetura de Dados](./docs/README.md)** - Visão de plataforma, ADRs e frameworks de decisão
+2. **🔄 [Projetos Práticos](./projects/README.md)** - Implementações com Airflow, dbt, Spark e monitoramento
+3. **📊 [Estudos de Caso](./case-studies/README.md)** - Cenários reais de tomada de decisão
+4. **👥 [Laboratório de Liderança](./leadership-lab/README.md)** - Desenvolvimento de habilidades de gestão
+5. **🚀 [Projetos End-to-End](./end-to-end/README.md)** - Integrações completas com documentação
+
+## 🌟 Objetivo
 
 Desenvolver as competências necessárias para:
-- Liderar equipes multidisciplinares de dados (Engenheiros, Cientistas e Analistas)
-- Projetar e implementar arquiteturas de dados modernas e escaláveis
-- Gerenciar projetos de dados end-to-end com entrega de valor mensurável
-- Comunicar efetivamente com stakeholders técnicos e de negócios
-- Equilibrar aspectos técnicos e de gestão no dia a dia
+- Liderar equipes multidisciplinares de dados
+- Projetar e implementar arquiteturas modernas e escaláveis
+- Gerenciar projetos end-to-end com valor mensurável
+- Comunicar efetivamente com stakeholders
+- Equilibrar aspectos técnicos e de gestão
 
-## Estrutura do Repositório
+## 🔍 Estrutura
 
-### `/docs`
-Documentação estratégica, incluindo visão de plataforma, ADRs (Architecture Decision Records), haikus arquiteturais e frameworks de decisão.
+Cada pasta numerada contém um README com explicações detalhadas e arquivos adicionais com casos de uso específicos:
 
-### `/projects`
-Projetos práticos individuais focados em tecnologias específicas (Airflow, dbt, Spark, monitoramento).
+- **/docs** - Documentação estratégica e decisões arquiteturais
+- **/projects** - Implementações práticas de tecnologias específicas
+- **/case-studies** - Análises de cenários reais
+- **/leadership-lab** - Templates e recursos de liderança
+- **/end-to-end** - Projetos integrados completos
 
-### `/case-studies`
-Estudos de casos e cenários de tomada de decisão, como modernização de plataforma, otimização de orçamento e priorização entre times.
-
-### `/leadership-lab`
-Recursos para desenvolvimento de habilidades de liderança, incluindo templates para one-on-ones, planos de desenvolvimento de equipe e modelos de feedback.
-
-### `/end-to-end`
-Projetos integrando múltiplas tecnologias da stack em casos de uso completos, com documentação e diagramas.
-
-## Roadmap de Desenvolvimento
-
-O arquivo [ROADMAP.md](ROADMAP.md) contém o plano detalhado de desenvolvimento ao longo de 90 dias, com metas semanais e recursos recomendados.
-
-## Stack Tecnológica em Foco
+## 🛠️ Stack Tecnológica
 
 - **Processamento**: Apache Spark, dbt
 - **Orquestração**: Apache Airflow
 - **Armazenamento**: Snowflake, Delta Lake
 - **Monitoramento**: Prometheus, ELK Stack
 - **Visualização**: Tableau, Looker
+
+## 📚 Recursos Principais
+
+- [Roadmap de Desenvolvimento](ROADMAP.md) - Plano detalhado de 90 dias
+- [Documentação da Plataforma](./docs/platform-vision.md) - Visão técnica e estratégica
+- [Frameworks de Decisão](./docs/decision-frameworks.md) - Guias para tomada de decisão
 
 ## Desafios e Cenários
 
@@ -48,7 +53,3 @@ Este repositório aborda cenários reais como:
 - Modernização de plataforma (ex: migração Redshift para Snowflake)
 - Otimização de orçamento com aumento de demandas
 - Desenvolvimento de cultura orientada a dados
-
-## Como Contribuir
-
-Sugestões e contribuições são bem-vindas através de issues e pull requests!

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,14 @@
-# Roadmap de Desenvolvimento para Head de Dados
+# 🗺️ Roadmap de Desenvolvimento para Head de Dados
+
+## 🎯 Sobre este Plano
 
 Este roadmap detalha um plano de 90 dias para desenvolver as competências necessárias para a posição de Head de Dados, com foco nas áreas identificadas como gaps: orquestração (Airflow), processamento moderno (dbt), monitoramento e governança de dados.
 
-## Fase 1: Fundamentos (Semanas 1-4)
+## 📋 Fases de Desenvolvimento
 
-### Semana 1: Configuração e Airflow Básico
+### 🌱 Fase 1: Fundamentos (Semanas 1-4)
+
+#### Semana 1: Configuração e Airflow Básico
 - [x] Criar estrutura do repositório
 - [ ] Configurar ambiente local com Docker para laboratórios
 - [ ] Estudar conceitos fundamentais do Airflow:
@@ -16,7 +20,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Curso "The Complete Hands-On Course to Master Apache Airflow"](https://www.udemy.com/course/the-complete-hands-on-course-to-master-apache-airflow/)
   - [ ] [Deploying Airflow in Docker](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html)
 
-### Semana 2: dbt Fundamentals
+#### Semana 2: dbt Fundamentals
 - [ ] Entender o paradigma do dbt e Analytics Engineering
 - [ ] Configurar projeto dbt básico
 - [ ] Implementar modelos, testes e documentação
@@ -25,7 +29,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [dbt Best Practices](https://docs.getdbt.com/guides/best-practices)
   - [ ] [Exemplo de projeto dbt](https://github.com/dbt-labs/jaffle_shop)
 
-### Semana 3: Monitoramento e Observabilidade
+#### Semana 3: Monitoramento e Observabilidade
 - [ ] Estudar conceitos de observabilidade vs. monitoramento
 - [ ] Configurar stack básico de monitoramento (Prometheus + Grafana)
 - [ ] Criar dashboards para métricas de pipelines de dados
@@ -34,7 +38,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Prometheus para monitoramento de dados](https://prometheus.io/docs/introduction/overview/)
   - [ ] [Grafana para visualização](https://grafana.com/docs/grafana/latest/)
 
-### Semana 4: Governança de Dados Fundamental
+#### Semana 4: Governança de Dados Fundamental
 - [ ] Estudar conceitos de qualidade, lineage e metadados
 - [ ] Explorar catálogos de dados open-source (Amundsen, DataHub)
 - [ ] Definir framework de governança para pipelines de dados
@@ -43,9 +47,9 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Amundsen Data Discovery](https://www.amundsen.io/amundsen/)
   - [ ] [Data Quality Dimensions Framework](https://www.dataversity.net/data-quality-dimensions/)
 
-## Fase 2: Integração e Aprofundamento (Semanas 5-8)
+### 🔄 Fase 2: Integração e Aprofundamento (Semanas 5-8)
 
-### Semana 5: Airflow Avançado
+#### Semana 5: Airflow Avançado
 - [ ] Implementar padrões de DAGs escaláveis
 - [ ] Configurar monitoramento do Airflow
 - [ ] Implementar testes para DAGs
@@ -53,7 +57,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Testing Airflow DAGs](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
   - [ ] [Airflow Metrics](https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html)
 
-### Semana 6: dbt + Spark Integration
+#### Semana 6: dbt + Spark Integration
 - [ ] Integrar dbt com Spark para transformações em grande escala
 - [ ] Implementar padrões de modelagem eficientes
 - [ ] Configurar monitoramento de jobs dbt
@@ -61,7 +65,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [dbt-spark adapter](https://docs.getdbt.com/reference/warehouse-setups/spark-setup)
   - [ ] [Optimizing Spark SQL](https://spark.apache.org/docs/latest/sql-performance-tuning.html)
 
-### Semana 7: Estratégia de Dados e Framework de Priorização
+#### Semana 7: Estratégia de Dados e Framework de Priorização
 - [ ] Desenvolver documento de visão de plataforma
 - [ ] Criar framework de priorização para demandas de diferentes áreas
 - [ ] Estudar cases de modernização de plataformas de dados
@@ -69,7 +73,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Data Strategy Framework](https://hbr.org/2018/05/what-your-company-needs-to-go-digital)
   - [ ] [RICE Scoring Model](https://www.productplan.com/glossary/rice-scoring-model/)
 
-### Semana 8: Liderança Técnica e Gestão de Equipes
+#### Semana 8: Liderança Técnica e Gestão de Equipes
 - [ ] Desenvolver templates para one-on-ones
 - [ ] Criar framework para feedback estruturado
 - [ ] Estudar modelos de desenvolvimento de equipes multidisciplinares
@@ -77,9 +81,9 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Radical Candor framework](https://www.radicalcandor.com/)
   - [ ] [The Manager's Path (Camille Fournier)](https://www.oreilly.com/library/view/the-managers-path/9781491973882/)
 
-## Fase 3: Projetos End-to-End (Semanas 9-12)
+### 🚀 Fase 3: Projetos End-to-End (Semanas 9-12)
 
-### Semana 9-10: Implementação de Pipeline Completo
+#### Semana 9-10: Implementação de Pipeline Completo
 - [ ] Criar projeto end-to-end integrando Airflow, dbt e Spark
 - [ ] Implementar monitoramento completo
 - [ ] Documentar arquitetura e decisões técnicas (ADR)
@@ -87,7 +91,7 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Modern Data Stack Architecture](https://www.databricks.com/glossary/data-lakehouse)
   - [ ] [ADR Templates](https://github.com/joelparkerhenderson/architecture-decision-record)
 
-### Semana 11-12: Consolidação e Revisão
+#### Semana 11-12: Consolidação e Revisão
 - [ ] Revisar todo o conteúdo desenvolvido
 - [ ] Preparar apresentação executiva da visão de plataforma
 - [ ] Desenvolver roadmap de evolução contínua
@@ -95,41 +99,41 @@ Este roadmap detalha um plano de 90 dias para desenvolver as competências neces
   - [ ] [Data Mesh Principles](https://martinfowler.com/articles/data-mesh-principles.html)
   - [ ] [Building a Data Platform Roadmap](https://medium.com/netflix-techblog/building-a-data-platform-to-enable-analytics-at-scale-2b676f9723e6)
 
-## Checkpoints e Avaliação
+## 🎯 Checkpoints e Avaliação
 
-### Checkpoint 1 (Final da Semana 4)
+### ✅ Checkpoint 1 (Final da Semana 4)
 - [ ] Ambiente de desenvolvimento configurado e funcionando
 - [ ] Projetos básicos de Airflow e dbt implementados
 - [ ] Entendimento fundamental de monitoramento e governança
 
-### Checkpoint 2 (Final da Semana 8)
+### ✅ Checkpoint 2 (Final da Semana 8)
 - [ ] Projetos integrados funcionando
 - [ ] Documentação estratégica inicial desenvolvida
 - [ ] Frameworks de decisão e priorização criados
 
-### Checkpoint 3 (Final da Semana 12)
+### ✅ Checkpoint 3 (Final da Semana 12)
 - [ ] Projeto end-to-end completo e documentado
 - [ ] Apresentação executiva de visão de plataforma pronta
 - [ ] Roadmap de evolução contínua definido
 
-## Recursos Adicionais Recomendados
+## 📚 Recursos Adicionais
 
-### Livros
+### 📖 Livros Recomendados
 - "Designing Data-Intensive Applications" por Martin Kleppmann
 - "The Data Warehouse Toolkit" por Ralph Kimball
 - "Data Management at Scale" por Piethein Strengholt
 - "Data Leadership" por Anthony Algmin
 
-### Comunidades e Fóruns
+### 👥 Comunidades e Fóruns
 - [Slack Community dbt](https://community.getdbt.com/)
 - [Apache Airflow Slack](https://apache-airflow.slack.com/)
 - [Data Engineering Subreddit](https://www.reddit.com/r/dataengineering/)
 
-### Newsletters
+### 📰 Newsletters
 - [Data Engineering Weekly](https://dataengineeringweekly.substack.com/)
 - [Seattle Data Guy](https://seattledataguy.substack.com/)
 - [The Data Engineering Podcast](https://www.dataengineeringpodcast.com/)
 
 ---
 
-Este roadmap é um documento vivo e será atualizado regularmente conforme o progresso e novos aprendizados.
+> 📝 Este roadmap é um documento vivo e será atualizado regularmente conforme o progresso e novos aprendizados.

--- a/case-studies/README.md
+++ b/case-studies/README.md
@@ -1,0 +1,44 @@
+# 📊 Estudos de Caso
+
+## 📝 Definição
+
+Esta seção contém análises detalhadas de cenários reais de tomada de decisão em plataformas de dados, incluindo modernização, otimização e priorização.
+
+## 🔄 Como Funciona
+
+```mermaid
+graph TD
+    A[Cenário] --> B[Análise]
+    B --> C[Alternativas]
+    C --> D[Decisão]
+    D --> E[Implementação]
+    E --> F[Resultados]
+```
+
+## 📊 Tipos de Casos
+
+### 🔄 Modernização de Plataforma
+- Migração Redshift para Snowflake
+- Adoção de Delta Lake
+- Implementação de dbt
+
+### 💰 Otimização de Custos
+- Análise de uso de recursos
+- Estratégias de cache
+- Dimensionamento de clusters
+
+### 📋 Priorização
+- Framework RICE para dados
+- Balanceamento entre times
+- Gestão de stakeholders
+
+### 🚨 Gestão de Incidentes
+- Postmortems
+- Planos de mitigação
+- Melhorias de processos
+
+## 🔗 Recursos Principais
+
+- [Templates de Análise](./templates/README.md)
+- [Framework de Decisão](./framework/README.md)
+- [Métricas de Sucesso](./metrics/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# 🏗️ Arquitetura de Dados
+
+## 📝 Definição
+
+Esta seção contém a documentação estratégica da plataforma de dados, incluindo decisões arquiteturais, visão técnica e frameworks de decisão.
+
+## 🔄 Como Funciona
+
+```mermaid
+graph TD
+    A[Visão de Plataforma] --> B[ADRs]
+    A --> C[Haikus Arquiteturais]
+    B --> D[Decisões Técnicas]
+    C --> D
+    D --> E[Implementação]
+```
+
+## 📊 Tipos Principais
+
+### 📑 ADRs (Architecture Decision Records)
+Documentação das decisões arquiteturais significativas tomadas no projeto, incluindo contexto, consequências e status.
+
+### 📜 Haikus Arquiteturais
+Representações concisas e poéticas de conceitos arquiteturais complexos, facilitando a comunicação e memorização.
+
+### 🎯 Frameworks de Decisão
+Guias estruturados para tomada de decisão em diferentes contextos da plataforma de dados.
+
+## 🔗 Casos de Uso
+
+- [ADRs](./adr/README.md) - Registro de decisões arquiteturais
+- [Haikus](./architecture-haikus/README.md) - Haikus arquiteturais
+- [Visão de Plataforma](./platform-vision.md) - Documento de visão técnica

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,0 +1,48 @@
+# 🚀 Projetos End-to-End
+
+## 📝 Definição
+
+Esta seção contém projetos completos que integram múltiplas tecnologias da Modern Data Stack em casos de uso reais, com documentação detalhada e diagramas.
+
+## 🔄 Como Funciona
+
+```mermaid
+graph TD
+    A[Ingestão] --> B[Processamento]
+    B --> C[Transformação]
+    C --> D[Armazenamento]
+    D --> E[Visualização]
+    F[Monitoramento] --> A
+    F --> B
+    F --> C
+    F --> D
+    F --> E
+```
+
+## 📊 Tipos de Projetos
+
+### 📈 Analytics Engineering
+- Pipeline completo com dbt
+- Modelagem dimensional
+- Testes e documentação
+
+### 🔄 Data Engineering
+- Ingestão com Airflow
+- Processamento com Spark
+- Armazenamento em Delta Lake
+
+### 📊 Data Science
+- Feature Engineering
+- Modelagem preditiva
+- Deployment de modelos
+
+### 🔍 Monitoramento
+- Métricas de qualidade
+- Alertas e dashboards
+- Observabilidade
+
+## 🔗 Recursos Principais
+
+- [Pipeline Analytics](./analytics-pipeline/README.md)
+- [Pipeline Machine Learning](./ml-pipeline/README.md)
+- [Pipeline Real-Time](./real-time-pipeline/README.md)

--- a/leadership-lab/README.md
+++ b/leadership-lab/README.md
@@ -1,0 +1,44 @@
+# 👥 Laboratório de Liderança
+
+## 📝 Definição
+
+Esta seção contém recursos e templates para desenvolvimento de habilidades de liderança em equipes de dados, incluindo one-on-ones, feedback e desenvolvimento de equipe.
+
+## 🔄 Como Funciona
+
+```mermaid
+graph TD
+    A[Avaliação] --> B[Planejamento]
+    B --> C[Execução]
+    C --> D[Feedback]
+    D --> E[Ajustes]
+    E --> A
+```
+
+## 📊 Áreas de Desenvolvimento
+
+### 👤 One-on-Ones
+- Templates de reunião
+- Guia de perguntas
+- Acompanhamento de ações
+
+### 📈 Desenvolvimento de Equipe
+- Planos individuais
+- Matriz de habilidades
+- Objetivos e métricas
+
+### 💬 Feedback
+- Framework Radical Candor
+- Feedback situacional
+- Documentação e follow-up
+
+### 🎯 Gestão de Performance
+- OKRs para dados
+- Avaliações técnicas
+- Planos de carreira
+
+## 🔗 Recursos Principais
+
+- [Templates de One-on-One](./one-on-ones/README.md)
+- [Framework de Feedback](./feedback/README.md)
+- [Planos de Desenvolvimento](./development/README.md)

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,43 @@
+# 🔄 Projetos Práticos
+
+## 📝 Definição
+
+Esta seção contém implementações práticas de tecnologias específicas da Modern Data Stack, com foco em Airflow, dbt, Spark e monitoramento.
+
+## 🔄 Como Funciona
+
+```mermaid
+graph TD
+    A[Conceito] --> B[Implementação Básica]
+    B --> C[Testes]
+    C --> D[Documentação]
+    D --> E[Integração]
+    E --> F[Monitoramento]
+```
+
+## 📊 Tipos de Projetos
+
+### 🌪️ Apache Airflow
+- [Fundamentos do Airflow](./airflow-fundamentals/README.md)
+- Padrões de DAGs
+- Monitoramento e Observabilidade
+
+### 🔧 dbt (data build tool)
+- [Fundamentos do dbt](./dbt-fundamentals/README.md)
+- Modelagem Dimensional
+- Testes e Documentação
+
+### ⚡ Apache Spark
+- [Fundamentos do Spark](./spark-fundamentals/README.md)
+- Otimização de Jobs
+- Integração com Delta Lake
+
+### 🔄 Projetos Integrados
+- [Pipeline End-to-End](./end-to-end-pipeline/README.md)
+- [dbt + Airflow: Análise de Voos](./dbt-airflow-flights/README.md)
+
+## 🔗 Recursos Principais
+
+- [Documentação do Airflow](https://airflow.apache.org/docs/)
+- [Documentação do dbt](https://docs.getdbt.com/)
+- [Documentação do Spark](https://spark.apache.org/docs/latest/)


### PR DESCRIPTION
## Descrição

Este PR padroniza a formatação de todos os arquivos markdown do repositório de acordo com a rule `repo-estudo`.

### Mudanças

- Adiciona emojis para melhor visualização e organização
- Padroniza estrutura dos READMEs:
  - Título com emoji
  - Seção "Sobre/Definição"
  - Diagrama Mermaid quando aplicável
  - Tipos/Categorias
  - Recursos/Links
- Remove seções proibidas (License/Contributing)
- Melhora organização visual dos conteúdos
- Adiciona diagramas mermaid para fluxos principais

### Arquivos Modificados

- README.md
- ROADMAP.md
- docs/README.md
- projects/README.md
- case-studies/README.md
- leadership-lab/README.md
- end-to-end/README.md

### Checklist

- [x] Emojis adicionados para melhor visualização
- [x] Estrutura padronizada em todos os arquivos
- [x] Seções proibidas removidas
- [x] Links e referências formatados corretamente
- [x] Diagramas mermaid adicionados onde relevante